### PR TITLE
fix: use correct case for viewBox attribute

### DIFF
--- a/template.js
+++ b/template.js
@@ -6,7 +6,7 @@ module.exports = (name, path) => `
     <svg
       :width="width"
       :height="height"
-      :view-box="viewBox"
+      :viewBox="viewBox"
       :xmlns="xmlns"
     >
       <title>MDI ${name}</title>


### PR DESCRIPTION
Fixes https://github.com/therufa/mdi-vue/issues/20.  Since this is an attribute on a normal svg element, as opposed to a property of a child component, it gets rendered as is without a conversion to camel case.