### PR TITLE
Remove svg title attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example.vue:
 </template>
 
 <script>
-import HookIcon 'mdi-vue/Hook' // works without an extension too
+import HookIcon from 'mdi-vue/Hook' // works without an extension too
 
 export {
   components: [

--- a/template.js
+++ b/template.js
@@ -9,7 +9,6 @@ module.exports = (name, path, ariaLabel) => `<template functional>
       :viewBox="props.viewBox"
       :xmlns="props.xmlns"
     >
-      <title>MDI ${name}</title>
       <path d="${path}" />
     </svg>
   </span>


### PR DESCRIPTION
Issue here: https://github.com/therufa/mdi-vue/issues/27

Why?

* Allow users to use their own title attributes in parent links
* Wording of title less good for accessibility