### PR TITLE
Link to icons.css from template

### DIFF
--- a/icons.css
+++ b/icons.css
@@ -1,7 +1,3 @@
-.mdi {
-  display: flex;
-}
-
 .mdi > svg {
   vertical-align: middle;
 }

--- a/template.js
+++ b/template.js
@@ -54,4 +54,6 @@ export default {
   }
 }
 </script>
+
+<style src="./icons.css"/>
 `


### PR DESCRIPTION
I feel like icons should render at the correct size by default without devs having to do anything additional, so this PR links `icons.css` to all icon components.

I did not test this, and instead wanted to get a read on whether you're open to a change like this before putting much effort into it. I have no idea what the possible downsides and complications of a change like this are (will all build systems correctly handle this?), so feel free to reject this if there are concerns. I didn't spend a lot of time on it.