### PR TITLE
FIX: Can't style icons with :class attribute

### DIFF
--- a/template.js
+++ b/template.js
@@ -2,7 +2,7 @@
 
 module.exports = (name, path, ariaLabel) => `<template functional>
   <span
-    :class="[data.staticClass, 'mdi', 'mdi-${name}', props.spin ? 'mdi-spin' : undefined]"
+    :class="[data.staticClass || '', 'mdi', 'mdi-${name}', props.spin ? 'mdi-spin' : undefined]"
     :role="props.role"
     :aria-label="props.ariaLabel"
   >


### PR DESCRIPTION
Fixes #43 

Following @therufa comment, I have added a fallback to the class attribute in the template file.