### PR TITLE
Quick README fix and Hack proposal to identify which vuejs version is in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Vue.use(mdiVue, {
 **Vue 3 example**  
 ```
 import { createApp } from 'vue'
+import mdiVue from 'mdi-vue'
 import * as mdijs from '@mdi/js'
 // `App` according to the vue 3 documentation
 

--- a/main.js
+++ b/main.js
@@ -4,8 +4,8 @@ import './icons.css'
 const { h: v3h } = require('vue') // import vue3's render function
 const isV2 = v3h === undefined
 
-const versionDependentOpts = Vue
-  ? { functional: true } // for v2.x
+const versionDependentOpts = (require('../vue/package.json').version.split('.',1)[0] < 3) 
+  ? { functional: true }  // for v2.x
   : {} // for v3.x
 
 const ucFirst = (str) => str.charAt(0).toUpperCase() + str.slice(1)


### PR DESCRIPTION
Hi,

I first saw a simple omission in the `README.md` file that I thought should be fixed.
Otherwise, this pull request is mainly targeting to hack around vuejs version detection at runtime which, for some unknown reason, doesn't seem like an easy task...

The actual "hack" consists on looking on the version of the `node_modules/vue/package.json' file and use it to avoid the ReferenceError we get when using Vue 3 on the master branch at the time of this pull request.
I refer to #50 ;)

Not the most elegant but it works. Up to you now ;)